### PR TITLE
E-mail restriction @verx.com.br

### DIFF
--- a/apps/web/src/app/api/oap_mcp/proxy-request.ts
+++ b/apps/web/src/app/api/oap_mcp/proxy-request.ts
@@ -221,7 +221,7 @@ export async function proxyRequest(req: NextRequest): Promise<Response> {
 
   try {
     // Logs de debug removidos para produção
-    console.log("targetUrl", targetUrl);
+    // console.log("targetUrl", targetUrl);
 
     // Make the proxied request
     const response = await fetch(targetUrl, {
@@ -230,7 +230,7 @@ export async function proxyRequest(req: NextRequest): Promise<Response> {
       body,
     });
 
-    console.log("response", response);
+    // console.log("response", response);
 
     // Clone the response to create a new one we can modify
     const responseClone = response.clone();

--- a/apps/web/src/features/signup/index.tsx
+++ b/apps/web/src/features/signup/index.tsx
@@ -28,9 +28,10 @@ const signupSchema = z
     companyName: z.string().optional(),
     email: z
       .string()
+      .min(1, "E-mail é obrigatório")
       .email("Por favor, insira um email válido")
       .refine(
-        (email) => email.endsWith("@verx.com.br"),
+        (email) => !email || email.endsWith("@verx.com.br"),
         "Apenas e-mails do domínio @verx.com.br são permitidos"
       ),
     password: z
@@ -99,7 +100,7 @@ export default function SignupInterface() {
     setAuthError(null);
 
     // Validação adicional de domínio
-    if (!formValues.email?.endsWith('@verx.com.br')) {
+    if (formValues.email && !formValues.email.endsWith('@verx.com.br')) {
       setAuthError('Apenas e-mails do domínio @verx.com.br são permitidos');
       return;
     }

--- a/apps/web/src/features/signup/index.tsx
+++ b/apps/web/src/features/signup/index.tsx
@@ -26,7 +26,13 @@ const signupSchema = z
     firstName: z.string().min(1, "Nome é obrigatório"),
     lastName: z.string().min(1, "Sobrenome é obrigatório"),
     companyName: z.string().optional(),
-    email: z.string().email("Por favor, insira um email válido"),
+    email: z
+      .string()
+      .email("Por favor, insira um email válido")
+      .refine(
+        (email) => email.endsWith("@verx.com.br"),
+        "Apenas e-mails do domínio @verx.com.br são permitidos"
+      ),
     password: z
       .string()
       .min(8, "Senha deve ter pelo menos 8 caracteres")
@@ -91,6 +97,12 @@ export default function SignupInterface() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setAuthError(null);
+
+    // Validação adicional de domínio
+    if (!formValues.email?.endsWith('@verx.com.br')) {
+      setAuthError('Apenas e-mails do domínio @verx.com.br são permitidos');
+      return;
+    }
 
     if (!validateForm()) return;
 
@@ -221,13 +233,17 @@ export default function SignupInterface() {
                 id="email"
                 name="email"
                 type="email"
-                placeholder="nome@exemplo.com"
+                placeholder="nome@verx.com.br"
                 value={formValues.email || ""}
                 onChange={handleInputChange}
                 aria-invalid={!!errors.email}
               />
-              {errors.email && (
+              {errors.email ? (
                 <p className="text-destructive text-sm">{errors.email}</p>
+              ) : (
+                <p className="text-muted-foreground text-xs">
+                  Apenas e-mails do domínio @verx.com.br são aceitos
+                </p>
               )}
             </div>
 

--- a/apps/web/src/features/signup/index.tsx
+++ b/apps/web/src/features/signup/index.tsx
@@ -32,7 +32,7 @@ const signupSchema = z
       .email("Por favor, insira um email válido")
       .refine(
         (email) => !email || email.endsWith("@verx.com.br"),
-        "Apenas e-mails do domínio @verx.com.br são permitidos"
+        "Apenas e-mails do domínio @verx.com.br são permitidos",
       ),
     password: z
       .string()
@@ -100,8 +100,8 @@ export default function SignupInterface() {
     setAuthError(null);
 
     // Validação adicional de domínio
-    if (formValues.email && !formValues.email.endsWith('@verx.com.br')) {
-      setAuthError('Apenas e-mails do domínio @verx.com.br são permitidos');
+    if (formValues.email && !formValues.email.endsWith("@verx.com.br")) {
+      setAuthError("Apenas e-mails do domínio @verx.com.br são permitidos");
       return;
     }
 

--- a/apps/web/src/lib/auth/supabase.ts
+++ b/apps/web/src/lib/auth/supabase.ts
@@ -86,6 +86,15 @@ export class SupabaseAuthProvider implements AuthProvider {
 
   async signUp(credentials: AuthCredentials) {
     try {
+      // Validação do domínio do e-mail
+      if (!credentials.email.endsWith('@verx.com.br')) {
+        throw {
+          message: 'Apenas e-mails do domínio @verx.com.br são permitidos',
+          status: 400,
+          code: 'invalid_email_domain'
+        };
+      }
+
       const { data, error } = await this.supabase.auth.signUp({
         email: credentials.email,
         password: credentials.password,

--- a/apps/web/src/lib/auth/supabase.ts
+++ b/apps/web/src/lib/auth/supabase.ts
@@ -87,11 +87,11 @@ export class SupabaseAuthProvider implements AuthProvider {
   async signUp(credentials: AuthCredentials) {
     try {
       // Validação do domínio do e-mail
-      if (!credentials.email.endsWith('@verx.com.br')) {
+      if (!credentials.email.endsWith("@verx.com.br")) {
         throw {
-          message: 'Apenas e-mails do domínio @verx.com.br são permitidos',
+          message: "Apenas e-mails do domínio @verx.com.br são permitidos",
           status: 400,
-          code: 'invalid_email_domain'
+          code: "invalid_email_domain",
         };
       }
 

--- a/cspell.json
+++ b/cspell.json
@@ -47,7 +47,8 @@
     "colecao",
     "padrao",
     "metadatas",
-    "esnext"
+    "esnext",
+    "verx"
   ],
   "enableFiletypes": [
     "javascript",


### PR DESCRIPTION
# Implementação de Validação de Domínio de E-mail

## Descrição
Esta feature implementa validação de domínio de e-mail para restringir o cadastro de usuários apenas ao domínio "@verx.com.br", garantindo que apenas usuários autorizados possam se registrar na plataforma.

## Alterações Realizadas

### Frontend
- Atualizado o schema de validação Zod no formulário de cadastro para incluir uma validação específica de domínio de e-mail
- Adicionada validação adicional no método [handleSubmit](cci:1://file:///home/gabriel-silveira/Projects/oap-via/web/apps/web/src/features/signup/index.tsx:96:2-137:4) para verificar o domínio antes de enviar a requisição
- Atualizado o campo de e-mail com placeholder e mensagem de ajuda informando sobre a restrição de domínio

### Backend
- Implementada validação de domínio no método [signUp](cci:1://file:///home/gabriel-silveira/Projects/oap-via/web/apps/web/src/lib/auth/supabase.ts:86:2-120:3) do [SupabaseAuthProvider](cci:2://file:///home/gabriel-silveira/Projects/oap-via/web/apps/web/src/lib/auth/supabase.ts:11:0-314:1)
- Adicionada verificação que rejeita e-mails que não terminam com "@verx.com.br"
- Configurado retorno de erro padronizado com código específico (`invalid_email_domain`) para facilitar o tratamento no frontend

## Abordagem Técnica
A implementação segue uma estratégia de validação em múltiplas camadas:

1. **Validação no Frontend (UX)**: Fornece feedback imediato ao usuário através do schema Zod
2. **Validação no Backend (Segurança)**: Garante que mesmo que o frontend seja contornado, o backend ainda validará o domínio

## Benefícios
- Restringe o acesso à plataforma apenas para usuários com e-mail corporativo
- Melhora a segurança do processo de cadastro
- Mantém a experiência do usuário com feedback claro e imediato
- Implementação não invasiva que não requer alterações no Supabase ou instalação de novos pacotes

## Testes
A validação pode ser testada de duas formas:
1. **Via Frontend**: Tentando se cadastrar com um e-mail de domínio diferente
2. **Via Backend**: Chamando diretamente o método [signUp](cci:1://file:///home/gabriel-silveira/Projects/oap-via/web/apps/web/src/lib/auth/supabase.ts:86:2-120:3) do [SupabaseAuthProvider](cci:2://file:///home/gabriel-silveira/Projects/oap-via/web/apps/web/src/lib/auth/supabase.ts:11:0-314:1)